### PR TITLE
fix: 프로필 설정하기 버튼이 보이지 않는 버그 수정 #249

### DIFF
--- a/src/Pages/ProfilePage.jsx
+++ b/src/Pages/ProfilePage.jsx
@@ -21,7 +21,6 @@ import { loginCheck } from 'Recoil/LoginCheck';
 import Modal from 'components/Common/Modal/Modal';
 import { Loading } from '../components/Profile/FollowListStyle';
 import MyPhraseList from 'components/MyPhrase/MyPhraseList';
-import { useGetInfiniteUserPosts } from 'API/Post';
 import { useGetMyPhrase } from 'Hooks/usePhrase';
 
 export default function ProfilePage() {
@@ -36,19 +35,6 @@ export default function ProfilePage() {
   const [view, setView] = useRecoilState(viewState);
   const [showNavBar, setShowNavBar] = useRecoilState(navBar);
   const [, setLoginCheck] = useRecoilState(loginCheck);
-  const { allUserPosts } = useGetInfiniteUserPosts(accountname);
-
-  const validUserPosts = allUserPosts.filter((post) => {
-    try {
-      post.parsedContent = JSON.parse(post.content);
-      return post.parsedContent.review;
-    } catch (error) {
-      return false;
-    }
-  });
-
-  const { phrase, myPhrase, fetchNextPhrase, hasNextPhrase } = useGetMyPhrase(accountname);
-  console.log(myPhrase);
 
   // 로그아웃 모달 버튼 상태
   const [showModalBtn, setshowModalBtn] = useState(false);
@@ -232,8 +218,6 @@ export default function ProfilePage() {
         onShowFollowers={handleShowFollowers}
         onShowFollowings={handleShowFollowings}
         activeButton={activeButton}
-        validUserPosts={validUserPosts}
-        myPhrase={myPhrase}
       />
       {content}
 
@@ -277,5 +261,4 @@ const FollowerHeader = styled.header`
 const SSectionTitle = styled.h2`
   flex: 1;
   margin-left: 30px;
-  line-height: 1.3;
 `;


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `✨feat: PR 등록`
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [ ] 💻 git rebase를 사용했나요?

<br>

## ⚡ PR 한 줄 요약
<!--수정/추가한 작업 내용을 설명해 주세요.-->
프로필 설정하기 버튼이 보이지 않는 버그 수정

<br><br>

## 🔍 상세 작업 내용
<!-- 작업한 상세 내용을 설명해 주세요.-->
- 프로필 페이지가 사용자의 프로필 페이지인지 다른 사용자의 프로필페이지인지 구별할 수 있도록 로그인 완료 시 accountname을 recoil로 관리하여 사용자의 프로필로 이동했을 때 프로필 설정하기 버튼이 나오도록 수정

<br><br>

## 💬 참고 사항
<!-- 참고할 만한 사항이 있다면 작성해 주세요. -->

<br><br>

## 💡 관련 이슈
<!-- 아래 이슈 번호를 작성하면 해당 이슈가 Close 됩니다. -->
<!-- ex) Close #14 -->

- Close #249 

<br><br>